### PR TITLE
ShowCharacterInventoryGrouped updates

### DIFF
--- a/Support/bin/ShowCharacterInventoryGrouped.py
+++ b/Support/bin/ShowCharacterInventoryGrouped.py
@@ -160,7 +160,8 @@ def main():
     total = distinct = 0
 
     # get Unicode names of all chars in doc; if not in Unicodedata, get them from UnicodeData.txt.zip
-    regExp = data = {}
+    regExp = {}
+    data = {}
     for ch in keys:
         try:
             data["%04X" % int(ch)] = unicodedata.name(wunichr(ch), "<")
@@ -174,7 +175,8 @@ def main():
                         bundleLibPath + "UnicodeData.txt.zip'").read().decode("UTF-8")
         for c in UnicodeData.splitlines():
             uniData = c.strip().split(';')
-            if len(uniData) > 1: data[uniData[0]] = uniData[1]
+            if len(uniData) > 1:
+                data[uniData[0]] = uniData[1]
 
     bgclasses = ['tr2', 'tr1']
 

--- a/Support/bin/ShowCharacterInventoryGrouped.py
+++ b/Support/bin/ShowCharacterInventoryGrouped.py
@@ -48,22 +48,21 @@ HEADER_HTML = """<html>
 
     body {
         font-family: 'Source Sans Pro', sans-serif;
-        font-size: 11pt;
+        font-size: 12pt;
     }
 
     pre, code, kbd, samp {
         font-family: "Droid Sans Mono", monospace;
-        font-size: 12pt;
+        font-size: 14pt;
     }
 
     table {
-        border: 1px solid #silver;
         border-collapse: collapse;
         width: 100%;
     }
 
     th {
-        font-size: 12pt;
+        font-size: larger;
         text-align: left;
         font-weight: 700;
         background-color: #333;
@@ -71,15 +70,19 @@ HEADER_HTML = """<html>
     }
 
     col {
-        width: 10%;
+        width: 15%;
     }
 
     col.name {
-        width: 50%;
+        width: 40%;
     }
 
     td {
-        padding: 1px;
+        padding: 1px 3px;
+    }
+
+    tr {
+        height: 2em;
     }
 
     tbody tr:nth-child(even) {
@@ -89,9 +92,17 @@ HEADER_HTML = """<html>
     .a {
         text-align: center;
     }
+
+    .c {
+        font-family: "Droid Sans Mono", monospace;
+        text-align: right;
+        padding-right: 1em;
+    }
+
     .tr1 {
         background-color: SandyBrown;
     }
+
     .tr2 {
         background-color: Cornsilk;
     }

--- a/Support/bin/ShowCharacterInventoryGrouped.py
+++ b/Support/bin/ShowCharacterInventoryGrouped.py
@@ -2,19 +2,21 @@
 # encoding: utf-8
 
 
-import sys
-import os
 import codecs
-import unicodedata
 import itertools
+import locale
+import os
+import sys
+import unicodedata
+
 from UniTools import *
-# import time
 
 sys.stdout = codecs.getwriter('utf-8')(sys.stdout)
 sys.stdin  = codecs.getreader('utf-8')(sys.stdin)
 
 bundleLibPath = os.environ["TM_BUNDLE_SUPPORT"] + "/lib/"
 
+locale.setlocale(locale.LC_ALL, locale.getdefaultlocale()[0])
 
 class SeqDict(dict):
     """Dict that remembers the insertion order."""
@@ -175,7 +177,7 @@ def main():
             # if groups[gr] has only one element shows up it as not grouped; otherwise bgcolor alternates
             if len(groups[gr]) == 1: clsstr = ''
             print "<tr class='" + clsstr + "'><td class='a'>", \
-                    t, "</td><td class='a'>", chKeys[c], "</td><td>", \
+                    t, "</td><td class='c'>", locale.format("%d", chKeys[c], grouping=True), "</td><td class='c'>", \
                     "U+%04X" % (int(c)), "</td><td>", getBlockName(c), "</td><td>", name, "</tr>"
 
     for c in unrel:
@@ -185,8 +187,8 @@ def main():
         name = data.get("%04X" % int(c), getNameForRange(c) + "-%04X" % int(c))
         if name == 1 or name[0] == '<': name = getNameForRange(c) + "-%04X" % int(c)
         if "COMBINING" in name: t = u"◌" + t
-        print "<tr><td class='a'>", t, "</td><td class='a'>", chKeys[c], \
-                "</td><td>", "U+%04X" % (int(c)), "</td><td>", \
+        print "<tr><td class='a'>", t, "</td><td class='c'>", locale.format("%d", chKeys[c], grouping=True), \
+                "</td><td class='c'>", "U+%04X" % (int(c)), "</td><td>", \
                 getBlockName(c), "</td><td>", name, "</tr>"
 
     print "</tbody></table>"
@@ -197,7 +199,9 @@ def main():
         pl = "s"
 
     print '<h2><a name="inventory">Character Inventory</a></h2>'
-    print "<p><i>%d character%s total, %d distinct</i></p>" % (total, pl, distinct)
+    print "<p><i>%s character%s total, %s distinct</i></p>" % (locale.format("%d", total, grouping=True),
+                                                               pl,
+                                                               locale.format("%d", distinct, grouping=True))
 
     print "<samp>"
     print " ".join(sorted((unichr(i) for i in chKeys.keys()), key=ord))

--- a/Support/bin/ShowCharacterInventoryGrouped.py
+++ b/Support/bin/ShowCharacterInventoryGrouped.py
@@ -40,7 +40,9 @@ class SeqDict(dict):
 
 
 HEADER_HTML = """<html>
-<head><title>Character Inventory</title>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<title>Character Inventory</title>
 <style type='text/css'>
     @import url(http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400italic,700|Droid+Sans+Mono&subset=latin,latin-ext);
 

--- a/Support/bin/ShowCharacterInventoryGrouped.py
+++ b/Support/bin/ShowCharacterInventoryGrouped.py
@@ -110,6 +110,19 @@ HEADER_HTML = """<html>
         text-align: center;
         cursor: pointer;
     }
+
+    table#character-inventory {
+        width: auto;
+        margin: auto;
+        text-align: center;
+        vertical-align: middle;
+    }
+
+    table#character-inventory td {
+        border: solid black 1px;
+        width: 2em;
+        height: 2em;
+    }
 </style>
 </head>
 <body>
@@ -153,7 +166,7 @@ def main():
             unrel.append(ch)
 
     print "<table>"
-    print """<colgroup><col class="character""/><col class="count"/><col class="codepoint"/><col class="block"/><col class="name"/></colgroup>"""
+    print """<colgroup><col class="character"/><col class="count"/><col class="codepoint"/><col class="block"/><col class="name"/></colgroup>"""
     print "<thead><tr><th>Character</th><th>Occurrences</th><th>UCS</th><th>Unicode Block</th><th>Unicode Name</th></tr></thead>"
     print "<tbody>"
 
@@ -170,13 +183,18 @@ def main():
         except TypeError:
             regExp["%04X" % int(ch)] = 1
 
+    # FIXME: make this a simple file scan rather than an unbounded regexp
     if regExp:
+        print >>sys.stderr, "Unmatched characters:"
+        print >>sys.stderr, regExp.keys()
         UnicodeData = os.popen("zgrep -E '^(" + "|".join(regExp.keys()) + ");' '" + \
                         bundleLibPath + "UnicodeData.txt.zip'").read().decode("UTF-8")
         for c in UnicodeData.splitlines():
             uniData = c.strip().split(';')
             if len(uniData) > 1:
                 data[uniData[0]] = uniData[1]
+
+    # FIXME: merge the two duplicate HTML output blocks and properly escape entities
 
     bgclasses = ['tr2', 'tr1']
 
@@ -218,9 +236,14 @@ def main():
                                                                pl,
                                                                locale.format("%d", distinct, grouping=True))
 
-    print "<samp>"
-    print " ".join(sorted((unichr(i) for i in chKeys.keys()), key=ord))
-    print "</samp>"
+    print '<table id="character-inventory">'
+    print '<tr>'
+    for i, c in enumerate(sorted((unichr(i) for i in chKeys.keys()), key=ord)):
+        if i > 0 and i % 25 == 0:
+            print '</tr><tr>'
+        print '<td>', c, '</td>',
+    print '</tr>'
+    print "</table>"
 
     print "</body></html>"
 


### PR DESCRIPTION
- Wrap the entire function into main() so PyPy will optimize it
- Use generators rather than reading all stdin into a list to avoid
  massive memory usage on large inputs
- Use Adobe Source Sans Pro and Droid Sans Mono via Google WebFonts
  for consistent character support
- Set table widths in CSS to reduce layout overhead
- zebra-stripe HTML output for easier reading across rows
- Print total character inventory at the bottom for easy scanning
  (this is particularly handy when comparing font support)
